### PR TITLE
feat: imprimir CV limpio con atajo

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -14,6 +14,7 @@ import {
   CommandItem,
 } from "@/components/ui/command";
 import { useCV } from "./cv-container";
+import { triggerPrint } from "@/lib/print";
 import { Button } from "./ui/button";
 // Importación de íconos de Lucide React.
 import {
@@ -57,7 +58,7 @@ export function CommandPalette({ className }: { className?: string }) {
   // Estado para controlar la visibilidad de la paleta de comandos.
   const [open, setOpen] = useState(false);
   // Hook personalizado para acceder a los datos y funciones del CV.
-  const { data } = useCV();
+  const { data, lang } = useCV();
   // Estado para detectar si el sistema operativo es macOS.
   const [isMac, setIsMac] = useState(false);
 
@@ -94,7 +95,7 @@ export function CommandPalette({ className }: { className?: string }) {
     {
       name: "Print Resume",
       icon: <Printer className="mr-2 h-4 w-4" />,
-      action: () => window.print(),
+      action: () => triggerPrint(lang),
       shortcut: "P",
     },
   ];

--- a/src/components/cv-container.tsx
+++ b/src/components/cv-container.tsx
@@ -89,7 +89,7 @@ export function CVContainer({ data: allData }: { data: Record<LanguageCode, CVDa
             <AnimatedSection>
                <SkillsSection />
             </AnimatedSection>
-            <AnimatedSection>
+            <AnimatedSection className="print:hidden">
               <ProjectsSection />
             </AnimatedSection>
           </main>

--- a/src/components/cv-container.tsx
+++ b/src/components/cv-container.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 // Importaciones de React, tipos y componentes.
-import React, { useState, createContext, useContext } from "react";
+import React, { useState, createContext, useContext, useEffect } from "react";
 import type { CVData } from "@/lib/types";
 import { CVSidebar } from "@/components/cv-sidebar";
 import { ExperienceSection } from "@/components/sections/experience";
@@ -12,6 +12,7 @@ import { ProjectsSection } from "@/components/sections/projects";
 import { CommandPalette } from "./command-palette";
 import { AnimatedSection } from "./animated-section";
 import type { LanguageCode } from "@/data";
+import { triggerPrint } from "@/lib/print";
 
 
 // Define la estructura del contexto del CV.
@@ -56,13 +57,25 @@ export function CVContainer({ data: allData }: { data: Record<LanguageCode, CVDa
     return <div>Loading...</div>;
   }
 
+  // Atajo de teclado para imprimir el CV.
+  useEffect(() => {
+    const handlePrint = (e: KeyboardEvent) => {
+      if (e.key === "p" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        triggerPrint(lang);
+      }
+    };
+    window.addEventListener("keydown", handlePrint);
+    return () => window.removeEventListener("keydown", handlePrint);
+  }, [lang]);
+
   return (
     // Proveedor de contexto que pasa el idioma, la función para cambiarlo y los datos actuales.
     <CVContext.Provider value={{ lang, setLang, data }}>
        {/* Contenedor principal con fondo y padding. */}
-       <div className="min-h-screen bg-background p-4 sm:p-8 md:p-12">
+       <div id="cv-content" className="min-h-screen bg-background p-4 sm:p-8 md:p-12">
         {/* Grid para el diseño de dos columnas en pantallas grandes. */}
-        <div className="mx-auto max-w-7xl grid grid-cols-1 lg:grid-cols-3 gap-12">
+        <div className="mx-auto max-w-7xl grid grid-cols-1 lg:grid-cols-3 gap-12 print:grid-cols-1">
           {/* Barra lateral pegajosa con la información principal. */}
           <CVSidebar />
           {/* Contenido principal con las diferentes secciones del CV. */}
@@ -83,7 +96,7 @@ export function CVContainer({ data: allData }: { data: Record<LanguageCode, CVDa
         </div>
       </div>
       {/* La paleta de comandos se añade aquí, pero podría estar oculta por defecto. */}
-      <CommandPalette />
+      <CommandPalette className="print:hidden" />
     </CVContext.Provider>
   );
 }

--- a/src/components/cv-sidebar.tsx
+++ b/src/components/cv-sidebar.tsx
@@ -116,7 +116,7 @@ export function CVSidebar({className}: {className?: string}) {
         </TooltipProvider>
 
         {/* Controles de la aplicación */}
-        <div className="flex items-center gap-2 mt-6">
+        <div className="flex items-center gap-2 mt-6 print:hidden">
           <LanguageToggle />
           <ThemeToggle />
           <CommandPalette />

--- a/src/lib/print.ts
+++ b/src/lib/print.ts
@@ -1,0 +1,7 @@
+export function triggerPrint(lang: string) {
+  if (typeof window === "undefined") return;
+  const previousTitle = document.title;
+  document.title = `cv-${lang}`;
+  window.print();
+  document.title = previousTitle;
+}


### PR DESCRIPTION
## Summary
- generar utilidad `triggerPrint` para nombrar y lanzar la impresión
- manejar `Ctrl/Cmd + P` para imprimir y ocultar controles en el PDF
- usar acción de la paleta de comandos para imprimir con idioma activo

## Testing
- `npm run lint` (configuración requerida, no se ejecutó)
- `npm run typecheck` *(falló: Conversion of type '...' may be a mistake)*

------
https://chatgpt.com/codex/tasks/task_e_6891032a00748325bdebca69e1b6dbc7